### PR TITLE
Add back version.json for dockerflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ celerymonitor.pid
 dist/
 docs/_build
 node_modules/
+version.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY bin /app/bin
 COPY dist /app/dist
 COPY missioncontrol /app/missioncontrol
 COPY manage.py setup.py tox.ini /app/
+COPY version.json /app/
 
 RUN chown webdev:webdev -R .
 USER webdev

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ help:
 
 build:
 	yarn build SERVICE_DOMAIN=""
+	touch version.json
 	docker-compose build
 
 migrate:


### PR DESCRIPTION
Fallout from https://github.com/mozilla/missioncontrol/pull/39/, we need this file to rebuild dev for the celery changes.