### PR TITLE
Copy everything in missioncontrol/ into docker container but use dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 .git
+docs
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,7 @@ RUN ./bin/pipstrap.py
 COPY requirements.txt /app/requirements.txt
 RUN pip install --require-hashes --no-cache-dir -r requirements.txt
 
-COPY bin /app/bin
-COPY dist /app/dist
-COPY missioncontrol /app/missioncontrol
-COPY manage.py setup.py tox.ini /app/
-
+COPY . /app
 RUN chown webdev:webdev -R .
 USER webdev
 


### PR DESCRIPTION
This makes installing version.json work again while still speeding things
up for the local dev case.