### PR TITLE
Fix building ui for docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 	@echo "  ci         Run tests, flake8 and docs"
 
 build:
-	yarn build SERVICE_DOMAIN=""
+	SERVICE_DOMAIN="" yarn build
 	docker-compose build
 
 migrate:


### PR DESCRIPTION
The environment variable wasn't being passed to docker correctly,
so we were always defaulting to the current dev instance for the
API server