### PR TITLE
Switch to using a .env file for setting environment variables

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,0 +1,8 @@
+DATABASE_URL=postgres://postgres@db/postgres
+PRESTO_URL=presto://presto:8080/hive/default
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1,
+SECRET_KEY=59114b6a-2858-4caf-8878-482a24ee9542
+CACHE_URL=redis://redis:6379/1
+LOGGING_USE_JSON=0
+MISSION_CONTROL_TABLE=error_aggregates

--- a/bin/test
+++ b/bin/test
@@ -9,5 +9,8 @@ export DEVELOPMENT=1
     echo "Getting Codecov environment variables" && \
     export CI_ENV=`bash <(curl -s https://codecov.io/env)`
 
+# Create environment
+cp .env-dist .env
+
 # run docker compose with the given environment variables
 docker-compose run -e DEVELOPMENT $CI_ENV web test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,15 +11,8 @@ services:
       build: .
       volumes:
         - .:/app
-      environment:
-        - DATABASE_URL=postgres://postgres@db/postgres
-        - PRESTO_URL=presto://presto:8080/hive/default
-        - DEBUG=True
-        - ALLOWED_HOSTS=localhost,127.0.0.1,
-        - SECRET_KEY=59114b6a-2858-4caf-8878-482a24ee9542
-        - CACHE_URL=redis://redis:6379/1
-        - LOGGING_USE_JSON=0
-        - MISSION_CONTROL_TABLE=error_aggregates
+      env_file:
+        - .env
       command: "true"
 
   web:


### PR DESCRIPTION
This allows us to modify variables for our development instance
(e.g. to use production presto)