### PR TITLE
Explicitly configure/set cache timeout of accessing the version endpoint

### DIFF
--- a/missioncontrol/etl/versions.py
+++ b/missioncontrol/etl/versions.py
@@ -1,7 +1,8 @@
 import requests
 from django.core.cache import cache
 
-from missioncontrol.settings import FIREFOX_VERSION_URL
+from missioncontrol.settings import (FIREFOX_VERSION_CACHE_TIMEOUT,
+                                     FIREFOX_VERSION_URL)
 
 
 def get_firefox_versions():
@@ -18,6 +19,6 @@ def get_firefox_versions():
         'beta': firefox_versions['LATEST_FIREFOX_DEVEL_VERSION'],
         'release': firefox_versions['LATEST_FIREFOX_VERSION']
     }
-    cache.set('firefox_versions', mapped_versions)
+    cache.set('firefox_versions', mapped_versions, FIREFOX_VERSION_CACHE_TIMEOUT)
 
     return mapped_versions

--- a/missioncontrol/settings.py
+++ b/missioncontrol/settings.py
@@ -309,5 +309,6 @@ LOGGING = {
 }
 
 FIREFOX_VERSION_URL = 'https://product-details.mozilla.org/1.0/firefox_versions.json'
+FIREFOX_VERSION_CACHE_TIMEOUT = 300
 
 DATA_EXPIRY_INTERVAL = timedelta(days=30)


### PR DESCRIPTION
We want it to be fairly low, as we want to display changes quickly.