### PR TITLE
Use system packages when running tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,13 +13,12 @@ setenv =
 passenv = SECRET_KEY ALLOWED_HOSTS DATABASE_URL PRESTO_URL
 
 [testenv:tests]
+sitepackages=True
 deps =
     pytest
     pytest-cov
     pytest-django
 commands =
-    {toxinidir}/bin/pipstrap.py
-    pip install --require-hashes --no-cache-dir -r requirements.txt -q
     pytest --cov=missioncontrol
 
 [testenv:flake8]


### PR DESCRIPTION
This is just to avoid reinstalling the python requirements in a new virtualenv on every test run.