### PR TITLE
Add a percentile filter to detail view

### DIFF
--- a/frontend/schema.js
+++ b/frontend/schema.js
@@ -8,4 +8,13 @@ export const TIME_INTERVALS = [
   { label: 'Last 14 days', interval: 1209600 }
 ];
 
+export const PERCENTILES = [
+  { label: 'All values', value: 100 },
+  { label: '99th percentile', value: 99 },
+  { label: '95th percentile', value: 95 },
+  { label: '75th percentile', value: 75 },
+  { label: '50th percentile', value: 50 }
+];
+
 export const DEFAULT_TIME_INTERVAL = 172800;
+export const DEFAULT_PERCENTILE = 99;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-addons-test-utils": "^15.5.1"
   },
   "dependencies": {
+    "aggregatejs": "^0.0.5",
     "bootstrap": "4.0.0-beta",
     "d3": "^4.9.1",
     "d3-time-format": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,6 +51,10 @@ acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
+aggregatejs@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/aggregatejs/-/aggregatejs-0.0.5.tgz#88d665601ec9c8262d6c39fb65b7a9dbe5b55d3e"
+
 ajv-keywords@^1.0.0, ajv-keywords@^1.1.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"


### PR DESCRIPTION
By default showing the 99th percentile of results (i.e. excluding the top
1%). Other options are 50, 75, 95, 100.