### PR TITLE
Don't update graphs unnecessarily in detail view

### DIFF
--- a/frontend/ui/detailgraph.jsx
+++ b/frontend/ui/detailgraph.jsx
@@ -1,12 +1,18 @@
-import _ from 'lodash';
 import React from 'react';
+import _ from 'lodash';
 import Dimensions from 'react-dimensions';
 import { curveLinear } from 'd3';
 import { timeFormat } from 'd3-time-format';
 import MetricsGraphics from 'react-metrics-graphics';
 
 
-class MeasureGraph extends React.Component {
+class DetailGraph extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return !_.isEqual(this.props.seriesList, nextProps.seriesList) ||
+      this.props.containerWidth !== nextProps.containerWidth ||
+      this.props.containerHeight !== nextProps.containerHeight;
+  }
+
   render() {
     const numSeries = this.props.seriesList.length;
     return (
@@ -20,7 +26,7 @@ class MeasureGraph extends React.Component {
         interpolate={curveLinear}
         missing_text="No data for this measure"
         x_accessor="date"
-        y_accessor={this.props.y || 'value'}
+        y_accessor={this.props.y}
         xax_format={this.props.xax_format ? timeFormat(this.props.xax_format) : undefined}
         xax_count={this.props.xax_count}
         linked={this.props.linked}
@@ -32,4 +38,4 @@ class MeasureGraph extends React.Component {
 }
 
 const dimensions = Dimensions;
-export default dimensions()(MeasureGraph);
+export default dimensions()(DetailGraph);

--- a/frontend/ui/detailview.jsx
+++ b/frontend/ui/detailview.jsx
@@ -1,4 +1,3 @@
-import percentile from 'aggregatejs/percentile';
 import React from 'react';
 import _ from 'lodash';
 import moment from 'moment';
@@ -8,7 +7,8 @@ import { connect } from 'react-redux';
 import { stringify } from 'query-string';
 
 import Loading from './loading.jsx';
-import MeasureGraph from './measuregraph.jsx';
+import DetailGraph from './detailgraph.jsx';
+import MeasureDetailGraph from './measuredetailgraph.jsx';
 import SubViewNav from './subviewnav.jsx';
 import {
   DEFAULT_PERCENTILE,
@@ -24,34 +24,6 @@ const mapStateToProps = (state, ownProps) => {
   const measureData = state.measures[cacheKey];
 
   return { measureData };
-};
-
-const getTransformedSeriesList = (seriesList, measure, normalized, percentileThreshold) => {
-  let newSeriesList = seriesList;
-
-  if (normalized) {
-    newSeriesList = newSeriesList.map(series => ({
-      ...series,
-      data: series.data.map(d => ({
-        ...d,
-        [measure]: d[measure] / (d.usage_hours / 1000.0)
-      }))
-    }));
-  }
-  if (percentileThreshold < 100) {
-    newSeriesList = newSeriesList.map((series) => {
-      const threshold = percentile(
-        series.data.map(d => d[measure]),
-        percentileThreshold / 100.0
-      );
-      return {
-        ...series,
-        data: series.data.filter(d => d[measure] < threshold)
-      };
-    });
-  }
-
-  return newSeriesList;
 };
 
 const getDateString = (date) => {
@@ -582,15 +554,11 @@ class DetailViewComponent extends React.Component {
                           <div
                             className="large-graph-container center"
                             id="measure-series">
-                            <MeasureGraph
-                              title={`${this.props.match.params.measure} ${(this.state.normalized) ? 'per 1k hours' : ''}`}
-                              seriesList={getTransformedSeriesList(
-                                  this.state.seriesList,
-                                  this.props.match.params.measure,
-                                  this.state.normalized,
-                                  this.state.percentile
-                                )}
-                              y={`${this.props.match.params.measure}`}
+                            <MeasureDetailGraph
+                              measure={this.props.match.params.measure}
+                              normalized={this.state.normalized}
+                              percentileThreshold={this.state.percentile}
+                              seriesList={this.state.seriesList}
                               linked={true}
                               linked_format="%Y-%m-%d-%H-%M-%S" />
                           </div>
@@ -601,7 +569,7 @@ class DetailViewComponent extends React.Component {
                           <div
                             className="large-graph-container center"
                             id="time-series">
-                            <MeasureGraph
+                            <DetailGraph
                               title="Usage khours"
                               seriesList={this.state.seriesList}
                               y={'usage_hours'}

--- a/frontend/ui/measuredetailgraph.jsx
+++ b/frontend/ui/measuredetailgraph.jsx
@@ -1,0 +1,47 @@
+import percentile from 'aggregatejs/percentile';
+import React from 'react';
+import Dimensions from 'react-dimensions';
+
+import DetailGraph from './detailgraph.jsx';
+
+
+class MeasureDetailGraph extends React.Component {
+  render() {
+    let transformedSeriesList = this.props.seriesList;
+
+    if (this.props.normalized) {
+      transformedSeriesList = transformedSeriesList.map(series => ({
+        ...series,
+        data: series.data.map(d => ({
+          ...d,
+          [this.props.measure]: d[this.props.measure] / (d.usage_hours / 1000.0)
+        }))
+      }));
+    }
+
+    if (this.props.percentileThreshold < 100) {
+      transformedSeriesList = transformedSeriesList.map((series) => {
+        const threshold = percentile(
+          series.data.map(d => d[this.props.measure]),
+          this.props.percentileThreshold / 100.0
+        );
+        return {
+          ...series,
+          data: series.data.filter(d => d[this.props.measure] < threshold)
+        };
+      });
+    }
+
+    return (
+      <DetailGraph
+        title={`${this.props.measure} ${(this.props.normalized) ? 'per 1k hours' : ''}`}
+        seriesList={transformedSeriesList}
+        y={`${this.props.measure}`}
+        linked={this.props.linked}
+        linked_format={this.props.linked_format} />
+    );
+  }
+}
+
+const dimensions = Dimensions;
+export default dimensions()(MeasureDetailGraph);


### PR DESCRIPTION
We were previously updating the measure/time graphs in the detail view
every time any aspect of the global state changed, even when such a
state did not effect the graphs at all (e.g. the user was just changing
the time picker). This operation could be extremely slow when we're
visualizing a large amount of data. Use react's shouldComponentUpdate
functionality to avoid unnecessary updates.