### PR TITLE
Make measure summary more meaningful

### DIFF
--- a/frontend/ui/subview.jsx
+++ b/frontend/ui/subview.jsx
@@ -27,6 +27,14 @@ const getFormattedNumber = (num) => {
   return numeral(num).format('0.00a');
 };
 
+const getDisplayInterval = (num, stdev) => {
+  const medianStr = `${getFormattedNumber(num)}`;
+  if (num && stdev) {
+    return `${medianStr} ± ${getFormattedNumber(stdev)}`;
+  }
+  return medianStr;
+};
+
 export class SubViewComponent extends React.Component {
   constructor(props) {
     super(props);
@@ -91,10 +99,10 @@ export class SubViewComponent extends React.Component {
                         </td>
                         <td>
                           <span title={`Version ${measure.latest.version}`}>
-                            {getFormattedNumber(measure.latest.median)}
+                            {getDisplayInterval(measure.latest.median, measure.latest.stdev)}
                           </span>
                         </td>
-                        <td>{getFormattedNumber(measure.previous.median)}</td>
+                        <td>{getDisplayInterval(measure.previous.median, measure.previous.stdev)}</td>
                         <td>{measure.lastUpdated ? moment(measure.lastUpdated).fromNow() : 'N/A'}</td>
                       </tr>
                     ))

--- a/missioncontrol/etl/measuresummary.py
+++ b/missioncontrol/etl/measuresummary.py
@@ -1,42 +1,84 @@
 import statistics
 
-from django.db.models import Max
-from django.utils import timezone
+from django.db.models import (Max, Min)
 
 from missioncontrol.base.models import Datum
-from missioncontrol.settings import DATA_EXPIRY_INTERVAL
-from .versions import get_current_firefox_version
+from missioncontrol.settings import (MEASURE_SUMMARY_VERSION_INTERVAL,
+                                     MEASURE_SUMMARY_SAMPLING_INTERVAL)
 
 
 def _get_summary_dict(values, version=None):
+    if not values:
+        return {
+            "version": version,
+            "mean": None,
+            "usageHours": 0
+        }
+
+    normalized_values = [v[0]/(v[1]/1000.0) for v in values]
     return {
         "version": version,
-        "median": statistics.median([v[0]/(v[1]/1000.0) for v in values]) if values else None,
-        "usageHours": sum([v[1] for v in values]) if values else 0
+        "median": round(statistics.median(normalized_values), 3),
+        "stdev": round(statistics.stdev(normalized_values), 3),
+        "usageHours": sum([v[1] for v in values])
     }
 
 
-def get_measure_summary(platform_name, channel_name, measure_name):
-    min_timestamp = timezone.now() - DATA_EXPIRY_INTERVAL
-    current_version = get_current_firefox_version(channel_name)
+def _get_data_interval_for_version(platform_name, channel_name, measure_name,
+                                   version, timestamp_offset, interval):
+    datums = Datum.objects.filter(
+        series__measure__name=measure_name,
+        series__build__channel__name=channel_name,
+        series__build__platform__name=platform_name,
+        series__build__version=version)
+    return list(
+        datums.filter(
+            timestamp__range=(timestamp_offset - interval, timestamp_offset)
+        ).values_list('value', 'usage_hours')
+    )
 
-    datums = Datum.objects.filter(series__measure__name=measure_name,
-                                  series__build__channel__name=channel_name,
-                                  series__build__platform__name=platform_name,
-                                  timestamp__gt=min_timestamp)
-    if not datums.exists():
+
+def get_measure_summary(platform_name, channel_name, measure_name):
+    '''
+    Returns a data structure summarizing the "current" status of a measure
+
+    A dictionary with a summary of the current median result over the last
+    24 hours, compared to previous versions.
+    '''
+    datums = Datum.objects.filter(
+        series__measure__name=measure_name,
+        series__build__channel__name=channel_name,
+        series__build__platform__name=platform_name)
+
+    version_data = datums.values_list(
+            'series__build__version').distinct().order_by(
+                '-series__build__version').annotate(Min('timestamp'), Max('timestamp'))
+    if not version_data:
         return {
-            "latest": _get_summary_dict([], current_version),
+            "latest": _get_summary_dict([]),
             "previous": _get_summary_dict([]),
             "lastUpdated": None
         }
 
-    latest_values = datums.filter(
-        series__build__version=current_version).values_list(
-            'value', 'usage_hours')
-    previous_values = datums.exclude(
-        series__build__version=current_version).values_list(
-            'value', 'usage_hours')
+    latest_version = version_data[0][0]
+    latest_values = _get_data_interval_for_version(
+        platform_name,
+        channel_name,
+        measure_name,
+        latest_version,
+        version_data[0][2],
+        MEASURE_SUMMARY_SAMPLING_INTERVAL)
+
+    start_offset = version_data[0][2] - version_data[0][1]
+    previous_values = []
+    for (version, start_timestamp, _) in version_data[1:1+MEASURE_SUMMARY_VERSION_INTERVAL]:
+        previous_values.extend(_get_data_interval_for_version(
+            platform_name,
+            channel_name,
+            measure_name,
+            version,
+            start_timestamp + start_offset,
+            MEASURE_SUMMARY_SAMPLING_INTERVAL))
 
     # set the last updated field
     if latest_values or previous_values:
@@ -45,7 +87,7 @@ def get_measure_summary(platform_name, channel_name, measure_name):
         last_updated = None
 
     return {
-        "latest": _get_summary_dict(latest_values, current_version),
+        "latest": _get_summary_dict(latest_values, latest_version),
         "previous": _get_summary_dict(previous_values),
         "lastUpdated": last_updated
     }

--- a/missioncontrol/settings.py
+++ b/missioncontrol/settings.py
@@ -314,3 +314,4 @@ FIREFOX_VERSION_CACHE_TIMEOUT = 300
 DATA_EXPIRY_INTERVAL = timedelta(days=60)
 MIN_CLIENT_COUNT = 100  # minimum number of client submissions for aggregate to be used
 MEASURE_SUMMARY_SAMPLING_INTERVAL = timedelta(days=1)
+MEASURE_SUMMARY_VERSION_INTERVAL = 4  # number of previous versions to consider

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,12 +48,14 @@ def test_measure_summary_incorporated(client, monkeypatch, prepopulated_version_
                         'lastUpdated': '2017-07-01T12:00:00Z',
                         'latest': {
                             'median': 625.0,
+                            'stdev': 2562.754,
                             'usageHours': 56.0,
                             'version': '55.0.1'
                         },
                         'name': 'main_crashes',
                         'previous': {
                             'median': 625.0,
+                            'stdev': 2562.754,
                             'usageHours': 56.0,
                             'version': None
                         }

--- a/tests/test_etl_measure.py
+++ b/tests/test_etl_measure.py
@@ -77,11 +77,13 @@ def test_get_measure_summary(fake_measure_data, prepopulated_version_cache):
         'lastUpdated': datetime.datetime(2017, 7, 1, 12, 0, tzinfo=tzutc()),
         'latest': {
             'median': 625.0,
+            'stdev': 2562.754,
             'usageHours': 56.0,
             'version': '55.0.1'
         },
         'previous': {
             'median': 625.0,
+            'stdev': 2562.754,
             'usageHours': 56.0,
             'version': None
         }


### PR DESCRIPTION
Instead of giving a median of the previous version's counts at the present
time (which is quite biased), calculate the previous version's counts at the
same time as the present one. This helps account for skew as people first
start to update to a previous version.

Also add standard deviation to the API endpoint (not using it yet, will soon)