### PR TITLE
Allow fetching just the measure data for specific versions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -64,6 +64,8 @@ Query parameters:
   is specified (see below)
 * `relative` (optional): If true (specified and non-zero), return results
   *from* the time of release of the latest version
+* `version` (optional): Retrieve only data particular to a specific version.
+  May be specified multiple times.
 
 Returns a dictionary with one element called `measure_data`, a dictionary
 whose keys are a set of buildids representing unique version, and whose


### PR DESCRIPTION
This feature is not yet exposed in the UI, but useful for some data analysis
I want to do on the side.