### PR TITLE
Allow skipping the first 24 hours in relative release view

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -58,12 +58,12 @@ Query parameters:
 * `platform` (required): Platform for measure (e.g. `windows`)
 * `measure` (required): Measure identifier (e.g. `main_crashes`)
 * `interval` (required): Interval of data to gather, in seconds
-* `start` (optional): Starting point to gather measure data from. If
-  not specified, will return `interval` worth of data, counting back
-  from the time of the query. This parameter is ignored if `relative`
-  is specified (see below)
 * `relative` (optional): If true (specified and non-zero), return results
   *from* the time of release of the latest version
+* `start` (optional): Starting point to gather measure data from. If
+  not specified, will return `interval` worth of data, counting either back
+  from the time of the query (non-relative) or up to the specified time
+  interval (relative).
 * `version` (optional): Retrieve only data particular to a specific version.
   May be specified multiple times.
 

--- a/missioncontrol/api/views.py
+++ b/missioncontrol/api/views.py
@@ -179,13 +179,17 @@ def measure(request):
                 'version': version,
                 'data': []
             }
+            if start:
+                start_timestamp = base_timestamp + datetime.timedelta(seconds=int(start))
+            else:
+                start_timestamp = base_timestamp
             ret[build_id]['data'] = [
                 [int((timestamp - base_timestamp).total_seconds()), value, usage_hours] for
                 (timestamp, value, usage_hours) in datums.filter(
                     series__build__version=version,
                     series__build__build_id=build_id,
-                    timestamp__range=(base_timestamp,
-                                      base_timestamp + datetime.timedelta(seconds=int(interval)))
+                    timestamp__range=(start_timestamp,
+                                      start_timestamp + datetime.timedelta(seconds=int(interval)))
                 ).order_by('timestamp').values_list('timestamp', 'value', 'usage_hours')]
 
     return JsonResponse(data={'measure_data': ret})


### PR DESCRIPTION
The first 24 hours of a release are extremely noisy, it's generally
best to ignore it when comparing releases after a sufficient amount
of time has passed.