### PR TITLE
Adjust how we handle negative and zero measure counts

### DIFF
--- a/missioncontrol/etl/measure.py
+++ b/missioncontrol/etl/measure.py
@@ -104,8 +104,11 @@ def update_measure(platform_name, channel_name, measure_name):
     datum_objs = []
     for (window_start, build_id, version, display_version, measure_count,
          usage_hours, client_count) in raw_query(query_template, params):
-        # skip datapoints with no measures / usage hours
-        if not measure_count or not usage_hours:
+        # skip datapoints with negative measure counts or no usage hours
+        # (in theory negative measures should be rejected at the ping
+        # validation level, but this is not yet the case at the time of this
+        # writing -- https://bugzilla.mozilla.org/show_bug.cgi?id=1447038)
+        if measure_count < 0 or usage_hours <= 0:
             continue
         series = series_cache.get((build_id, version))
         if not series:


### PR DESCRIPTION
* Skip negative measure counts -- in theory they should be rejected at the
  ping validation level but this is not yet the case
  (https://bugzilla.mozilla.org/show_bug.cgi?id=1447038)
* Allow zero-based measure counts (these can be useful for knowing that
  we're counting stuff even if there are no errors to report)