### PR TITLE
Make minimum client count threshold used for presto configurable per-channel

### DIFF
--- a/missioncontrol/base/fixtures/base_metadata.yaml
+++ b/missioncontrol/base/fixtures/base_metadata.yaml
@@ -21,21 +21,25 @@
   fields:
     name: release
     update_interval: 42 00:00:00 # = 6 weeks
+    min_expected_client_count: 1000
 - model: base.Channel
   pk: 2
   fields:
     name: beta
     update_interval: 14 00:00:00
+    min_expected_client_count: 10
 - model: base.Channel
   pk: 3
   fields:
     name: nightly
     update_interval: 3 00:00:00
+    min_expected_client_count: 10
 - model: base.Channel
   pk: 4
   fields:
     name: esr
     update_interval: 42 00:00:00 # = 6 weeks
+    min_expected_client_count: 50
 
 # measures (some are also in load_initial_data)
 - model: base.Measure

--- a/missioncontrol/base/models.py
+++ b/missioncontrol/base/models.py
@@ -18,6 +18,7 @@ class Channel(models.Model):
     '''
     name = models.CharField(max_length=100, unique=True)
     update_interval = models.DurationField()
+    min_expected_client_count = models.PositiveIntegerField()
 
     class Meta:
         db_table = 'channel'

--- a/missioncontrol/etl/measure.py
+++ b/missioncontrol/etl/measure.py
@@ -17,7 +17,6 @@ from missioncontrol.base.models import (Build,
                                         Platform,
                                         Series)
 from missioncontrol.settings import (MEASURE_SUMMARY_CACHE_EXPIRY,
-                                     MIN_CLIENT_COUNT,
                                      MISSION_CONTROL_TABLE)
 from .measuresummary import (get_measure_summary_cache_key,
                              get_measure_summary)
@@ -92,7 +91,7 @@ def update_measure(platform_name, channel_name, measure_name):
         'min_build_id': min_buildid_timestamp.strftime('%Y%m%d'),
         'os_name': platform.telemetry_name,
         'channel_name': channel_name,
-        'min_client_count': MIN_CLIENT_COUNT,
+        'min_client_count': channel.min_expected_client_count,
         'min_timestamp': min_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
         'min_submission_date': min_timestamp.strftime("%Y-%m-%d")
     }

--- a/missioncontrol/settings.py
+++ b/missioncontrol/settings.py
@@ -348,7 +348,6 @@ FIREFOX_EXPERIMENTS_URL = ('https://normandy.cdn.mozilla.net/api/v1/recipe/'
                            'signed/?enabled=true&' 'latest_revision__action=3')
 
 DATA_EXPIRY_INTERVAL = timedelta(days=120)
-MIN_CLIENT_COUNT = 100  # minimum number of client submissions for aggregate to be used
 MEASURE_SUMMARY_SAMPLING_INTERVAL = timedelta(days=1)
 MEASURE_SUMMARY_VERSION_INTERVAL = 3  # maximum number of previous major versions to consider
 MEASURE_SUMMARY_CACHE_EXPIRY = 24 * 60 * 60  # keep measure summaries in cache for up to one day


### PR DESCRIPTION
On some channels, we needed to reduce it (i.e. linux or mac nightly or beta)
on others we want to increase it (linux release) to reduce the long tail of
random submitters we have to take into account.