### PR TITLE
Allow toggling between counts and rates on summary page

### DIFF
--- a/missioncontrol/etl/measuresummary.py
+++ b/missioncontrol/etl/measuresummary.py
@@ -115,15 +115,17 @@ def get_measure_summary(platform_name, channel_name, measure_name):
                 'version': version[0],
                 'fieldDuration': int(field_duration.total_seconds())
             }
-            for (mean_id, interval) in (('mean', version_end - version_start),
-                                        ('adjustedMean', latest_version_interval)):
-
+            for (mean_id, count_id, interval) in (
+                    ('rate', 'count', version_end - version_start),
+                    ('adjustedRate', 'adjustedCount', latest_version_interval)
+            ):
                 values = _get_data_interval_for_version(platform_name,
                                                         channel_name,
                                                         measure_name,
                                                         version[0],
                                                         version_start,
                                                         version_start + interval)
+                version_data[count_id] = int(sum([v[0] for v in values]))
                 normalized_values = [v[0]/(v[1]/1000.0) for v in values]
                 if len(normalized_values) > 1:
                     version_data[mean_id] = round(statistics.mean(normalized_values), 2)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,15 +49,19 @@ def test_measure_summary_incorporated(client, monkeypatch, prepopulated_version_
                         'lastUpdated': '2017-07-01T12:00:00Z',
                         'versions': [
                             {
-                                'adjustedMean': 2041.67,
+                                'adjustedCount': 120,
+                                'adjustedRate': 2041.67,
+                                'count': 120,
                                 'fieldDuration': 600,
-                                'mean': 2041.67,
+                                'rate': 2041.67,
                                 'version': '55.0.1'
                             },
                             {
-                                'adjustedMean': 2041.67,
+                                'adjustedCount': 240,
+                                'adjustedRate': 2041.67,
+                                'count': 240,
                                 'fieldDuration': 600,
-                                'mean': 2041.67,
+                                'rate': 2041.67,
                                 'version': '55'
                             }
                         ]

--- a/tests/test_etl_measure.py
+++ b/tests/test_etl_measure.py
@@ -82,15 +82,19 @@ def test_get_measure_summary(fake_measure_data, prepopulated_version_cache):
         'lastUpdated': datetime.datetime(2017, 7, 1, 12, 0, tzinfo=tzutc()),
         'versions': [
             {
-                'adjustedMean': 2041.67,
+                'adjustedCount': 120,
+                'adjustedRate': 2041.67,
+                'count': 120,
                 'fieldDuration': 600,
-                'mean': 2041.67,
+                'rate': 2041.67,
                 'version': '55.0.1'
             },
             {
-                'adjustedMean': 2041.67,
+                'adjustedCount': 240,
+                'adjustedRate': 2041.67,
+                'count': 240,
                 'fieldDuration': 600,
-                'mean': 2041.67,
+                'rate': 2041.67,
                 'version': '55'
             }
         ]

--- a/tests/test_measuresummary.py
+++ b/tests/test_measuresummary.py
@@ -55,14 +55,18 @@ def test_get_measure_summary(base_datapoint_time, prepopulated_version_cache,
                 "versions": [
                     {
                         "version": "55.0",
-                        "adjustedMean": 250.0,
-                        "mean": 250.0,
+                        "adjustedCount": 1,
+                        "count": 1,
+                        "adjustedRate": 250.0,
+                        "rate": 250.0,
                         "fieldDuration": 3600
                     },
                     {
                         "version": "55",
-                        "adjustedMean": 250.0,
-                        "mean": 250.0,
+                        "adjustedCount": 1,
+                        "adjustedRate": 250.0,
+                        "count": 1,
+                        "rate": 250.0,
                         "fieldDuration": 3600
                     }
                 ],


### PR DESCRIPTION
Sometimes it is useful to see the raw counts of various errors (esp. crashes)
for comparison with other tools or just generally.