### PR TITLE
Show values that are *at* the percentile in detail view

### DIFF
--- a/frontend/ui/measuredetailgraph.jsx
+++ b/frontend/ui/measuredetailgraph.jsx
@@ -27,7 +27,7 @@ class MeasureDetailGraph extends React.Component {
 
         return {
           ...series,
-          data: series.data.filter(d => d[this.props.measure] < threshold),
+          data: series.data.filter(d => d[this.props.measure] <= threshold),
         };
       });
     }


### PR DESCRIPTION
Only showing those below the percentile threshold could cause errors
if there are a low number of non-zero datapoints.