### PR TITLE
Use a variant of alphanumeric version sorting in release summary view

### DIFF
--- a/frontend/ui/subview.jsx
+++ b/frontend/ui/subview.jsx
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import versionSort from 'version-sort';
 import moment from 'moment';
 import numeral from 'numeral';
 import React from 'react';
@@ -23,15 +22,15 @@ const mapStateToProps = (state, ownProps) => {
     if (channelPlatformData.length) {
       return {
         measures: channelPlatformData[0].measures,
-        versions: versionSort(
-          _.uniq(
-            _.flatten(
-              channelPlatformData[0].measures.map(measure =>
-                measure.versions.map(version => version.version)
-              )
+        versions: _.uniq(
+          _.flatten(
+            channelPlatformData[0].measures.map(measure =>
+              measure.versions.map(version => version.version)
             )
           )
-        ).reverse(),
+        )
+          .sort()
+          .reverse(),
         latestReleaseAge: _.min(
           _.flatten(
             channelPlatformData[0].measures.map(measure =>


### PR DESCRIPTION
This is what we actually want, given that we are sorting a list that
normally includes a summary of each release number ('60') and *one*
specific beta/alpha/point release which is the latest ('59.0.3')