### PR TITLE
Better calculation/rendering of latest version field duration

### DIFF
--- a/frontend/ui/subview.jsx
+++ b/frontend/ui/subview.jsx
@@ -20,11 +20,13 @@ const mapStateToProps = (state, ownProps) => {
     );
 
     if (channelPlatformData.length) {
+      const channelPlatformSummary = channelPlatformData[0];
+
       return {
-        measures: channelPlatformData[0].measures,
+        measures: channelPlatformSummary.measures,
         versions: _.uniq(
           _.flatten(
-            channelPlatformData[0].measures.map(measure =>
+            channelPlatformSummary.measures.map(measure =>
               measure.versions.map(version => version.version)
             )
           )
@@ -35,13 +37,7 @@ const mapStateToProps = (state, ownProps) => {
             return difference || a.localeCompare(b);
           })
           .reverse(),
-        latestReleaseAge: _.min(
-          _.flatten(
-            channelPlatformData[0].measures.map(measure =>
-              measure.versions.map(version => version.fieldDuration)
-            )
-          )
-        ),
+        latestReleaseAge: channelPlatformSummary.latestVersionFieldDuration,
       };
     }
   }
@@ -209,16 +205,17 @@ export class SubViewComponent extends React.Component {
                     ))}
                 </tbody>
               </table>
-              {this.props.latestReleaseAge < 86400 && (
-                <p className="text-danger">
-                  <center>
-                    Latest release is new ({moment
-                      .duration(this.props.latestReleaseAge, 'seconds')
-                      .humanize()}{' '}
-                    in field), numbers should be viewed with skepticism
-                  </center>
-                </p>
-              )}
+              {this.props.latestReleaseAge &&
+                this.props.latestReleaseAge < 86400 && (
+                  <p className="text-danger">
+                    <center>
+                      Latest release is new ({moment
+                        .duration(this.props.latestReleaseAge, 'seconds')
+                        .humanize()}{' '}
+                      in field), numbers should be viewed with skepticism
+                    </center>
+                  </p>
+                )}
             </div>
           )}
         </div>

--- a/missioncontrol/api/views.py
+++ b/missioncontrol/api/views.py
@@ -94,14 +94,21 @@ def channel_platform_summary(request):
                 }
                 measure_summary_map = cache.get_many(measure_name_map.keys())
                 latest_version_seen = None
+                latest_version_field_duration = None
                 if measure_summary_map.values():
                     latest_version_seen = _sorted_version_list(
                         [measure_summary['versions'][0]['version'] for
                          measure_summary in measure_summary_map.values()])[0]
+                    latest_version_field_duration = max(
+                        [measure_summary['versions'][0]['fieldDuration'] for
+                         measure_summary in measure_summary_map.values() if
+                         measure_summary['versions'][0]['version'] ==
+                         latest_version_seen])
                 summaries.append({
                     'application': application.name,
                     'expectedMeasures': list(measure_names),
                     'latestVersionSeen': latest_version_seen,
+                    'latestVersionFieldDuration': latest_version_field_duration,
                     'channel': channel.name,
                     'platform': platform.name,
                     'measures': [{

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,6 +33,7 @@ def test_get_channel_platform_summary_no_data(client, monkeypatch,
                         'channel': channel_name,
                         'platform': platform_name,
                         'latestVersionSeen': None,
+                        'latestVersionFieldDuration': None,
                         'expectedMeasures': list(
                             expected_measures.values_list('name', flat=True)),
                         'measures': []
@@ -60,6 +61,7 @@ def test_measure_summary_incorporated(client, monkeypatch, prepopulated_version_
                 'application': 'firefox',
                 'channel': 'release',
                 'platform': 'linux',
+                'latestVersionFieldDuration': 600,
                 'latestVersionSeen': '55.0.1',
                 'expectedMeasures': list(Measure.objects.filter(
                     channels=Channel.objects.filter(name='release'),


### PR DESCRIPTION
* Calculate it server side
* Use the highest number we have (since some measures might be out of date
  if we haven't done a backfill for them)