### PR TITLE
Load all measures per platform/channel simultaneously (fixes #115)

### DIFF
--- a/missioncontrol/etl/management/commands/load_measure_data.py
+++ b/missioncontrol/etl/management/commands/load_measure_data.py
@@ -4,11 +4,11 @@ from django.core.management.base import (BaseCommand,
                                          CommandError)
 from dateutil import parser
 
-from missioncontrol.etl.measure import update_measure
+from missioncontrol.etl.measure import update_measures
 
 
 class Command(BaseCommand):
-    """Management command to update data for a specific measure/platform/channel combination."""
+    """Management command to update data for a specific platform/channel combination."""
 
     def add_arguments(self, parser):
         parser.add_argument('application', metavar='application', type=str,
@@ -17,8 +17,6 @@ class Command(BaseCommand):
                             help='platform to fetch data for')
         parser.add_argument('channel', metavar='channel', type=str,
                             help='channel to fetch data for')
-        parser.add_argument('measure', metavar='measure', type=str,
-                            help='measure to fetch data for')
         parser.add_argument('--start-date', dest='start_date')
         parser.add_argument('--end-date', dest='end_date')
 
@@ -32,10 +30,10 @@ class Command(BaseCommand):
                             parser.parse(end_date + ' -0000'))
             current = start
             while current <= end:
-                update_measure(options['application'], options['platform'],
-                               options['channel'], options['measure'],
-                               submission_date=current, bulk_create=False)
+                update_measures(options['application'], options['platform'],
+                                options['channel'], submission_date=current,
+                                bulk_create=False)
                 current += datetime.timedelta(days=1)
         else:
-            update_measure(options['application'], options['platform'],
-                           options['channel'], options['measure'])
+            update_measures(options['application'], options['platform'],
+                            options['channel'])

--- a/missioncontrol/etl/measuresummary.py
+++ b/missioncontrol/etl/measuresummary.py
@@ -62,6 +62,7 @@ def get_measure_summary(application_name, platform_name, channel_name, measure_n
                                   version__gte=min_version,
                                   version__lt=str(current_major_version + 1))
     measure = Measure.objects.get(name=measure_name,
+                                  application__name=application_name,
                                   platform__name=platform_name)
     datums = Datum.objects.filter(build__in=builds,
                                   measure=measure)

--- a/missioncontrol/settings.py
+++ b/missioncontrol/settings.py
@@ -250,9 +250,9 @@ CELERY_BEAT_SCHEDULE = {}
 FETCH_MEASURE_DATA = config('FETCH_MEASURE_DATA', default=True, cast=bool)
 if FETCH_MEASURE_DATA:
     CELERY_BEAT_SCHEDULE.update({
-        'fetch_measure_data': {
+        'fetch_channel_measure_data': {
             'schedule': crontab(minute='*/5'),  # every 5 minutes
-            'task': 'missioncontrol.etl.tasks.update_measures',
+            'task': 'missioncontrol.etl.tasks.update_channels_measures',
             'options': {
                 'expires': 5 * 60
             }


### PR DESCRIPTION
This is actually only a little more data per-query than getting the data
one-measure-at-a-time and allows us to hugely reduce both the number of
athena queries we make and the amount of time we spend making them.