### PR TITLE
Fix filtering based on percentiles

### DIFF
--- a/frontend/ui/detailview.jsx
+++ b/frontend/ui/detailview.jsx
@@ -354,7 +354,7 @@ class DetailViewComponent extends React.Component {
 
         return {
           ...series,
-          data: series.data.filter(d => d[measure] < threshold),
+          data: series.data.filter(d => d[measure] <= threshold),
         };
       });
     }


### PR DESCRIPTION
Filter based on an aggregate being less than or equal to the percentile,
rather than just less than. This avoids filtering out the entire dataset
if we just have zeros, which happens sometimes.