### PR TITLE
Adds MAX_VISIBLE_SERIES const for showing detailed view

### DIFF
--- a/frontend/schema.js
+++ b/frontend/schema.js
@@ -47,6 +47,11 @@ export const DEFAULT_TIME_INTERVAL = 1209600;
 export const DEFAULT_TIME_INTERVAL_RELATIVE = 604800;
 export const DEFAULT_PERCENTILE = 99;
 export const DEFAULT_VERSION_GROUPING_TYPE = 'version';
+export const MAX_VISIBLE_SERIES = {
+  release: 5,
+  beta: 3,
+  nightly: 2,
+};
 
 export const KEY_MEASURES = ['content_crashes', 'main_crashes'];
 

--- a/frontend/ui/detailview.jsx
+++ b/frontend/ui/detailview.jsx
@@ -31,6 +31,7 @@ import {
   PERCENTILES,
   TIME_INTERVALS,
   TIME_INTERVALS_RELATIVE,
+  MAX_VISIBLE_SERIES,
 } from '../schema';
 import { semVerCompare } from '../version';
 
@@ -280,9 +281,10 @@ class DetailViewComponent extends React.Component {
 
     const sortedSeriesValues = data =>
       _.values(data).sort((a, b) => a.date - b.date);
+    const maxVisibleSeries = MAX_VISIBLE_SERIES[this.state.channel];
+    // if we have <= maxVisibleSeries series, just return all verbatim
 
-    // if we have <= 3 series, just return all verbatim
-    if (Object.keys(seriesMap).length <= 3) {
+    if (Object.keys(seriesMap).length <= maxVisibleSeries) {
       return _.map(seriesMap, (data, name) => ({
         name,
         data: sortedSeriesValues(data),
@@ -291,10 +293,10 @@ class DetailViewComponent extends React.Component {
         .reverse();
     }
 
-    // take two most recent versions
+    // take maxVisibleSeries most recent versions
     let mostRecent = Object.keys(seriesMap)
       .sort(semVerCompare)
-      .slice(-2);
+      .slice(-maxVisibleSeries);
 
     // if the second most recent has negligible results (<10% of) relative
     // to the most recent, just concatenate it in with the other results under


### PR DESCRIPTION
Fixes #320.

Added MAX_VISIBLE_SERIES constant in `schema.js` and set it to 5.
Here is a screenshot which shows plots for 5 versions. 
![screenshot from 2018-10-29 18-24-05](https://user-images.githubusercontent.com/39922958/47651169-78a70300-dba8-11e8-98cc-868856d68ff9.png)

Please let me know if this works. Also, should we add a button to set the MAX_VISIBLE_SERIES?
@wlach 
