### PR TITLE
Throw a clearer exception in cases where we aren't getting builds from buildhub

### DIFF
--- a/missioncontrol/etl/measure.py
+++ b/missioncontrol/etl/measure.py
@@ -81,6 +81,9 @@ def update_measures(application_name, platform_name, channel_name,
                 build_id__lte=max_buildid_timestamp.strftime('%Y%m%d')).values_list(
                     'version', flat=True)
         ), key=parse_version)
+    if not valid_versions:
+        raise Exception('No valid versions found for combination: {}'.format(
+            '/'.join(('application', 'channel', 'platform'))))
     (min_version, max_version) = (get_major_version(valid_versions[0]),
                                   get_major_version(valid_versions[-1]) + 1)
 

--- a/tests/test_etl_measure.py
+++ b/tests/test_etl_measure.py
@@ -33,6 +33,14 @@ def mock_raw_query(monkeypatch, mock_raw_query_data):
     monkeypatch.setattr(missioncontrol.etl.presto, 'raw_query', _raw_query)
 
 
+def test_update_measures_no_build_data(initial_data, mock_raw_query,
+                                       mock_raw_query_data):
+    (application, platform, channel) = ('firefox', 'linux', 'release')
+    with pytest.raises(Exception, match='No valid versions'):
+        from missioncontrol.etl.measure import update_measures
+        update_measures(application, platform, channel)
+
+
 @freeze_time('2017-07-01 13:00')
 def test_update_measures(prepopulated_builds,
                          mock_raw_query,


### PR DESCRIPTION
We were throwing a list index error before in the measure etl code, which was
less than clear.