### PR TITLE
Fixes date issue in snapshot test

### DIFF
--- a/frontend/test/components/__snapshots__/measuretable.spec.jsx.snap
+++ b/frontend/test/components/__snapshots__/measuretable.spec.jsx.snap
@@ -180,7 +180,7 @@ ShallowWrapper {
                 N/A
               </td>
               <td>
-                2 hours ago
+                a few seconds ago
               </td>
             </tr>
           </tbody>
@@ -282,7 +282,7 @@ ShallowWrapper {
                   N/A
                 </td>
                 <td>
-                  2 hours ago
+                  a few seconds ago
                 </td>
               </tr>
             </tbody>,
@@ -520,7 +520,7 @@ ShallowWrapper {
                     N/A
                   </td>
                   <td>
-                    2 hours ago
+                    a few seconds ago
                   </td>
                 </tr>,
               ],
@@ -578,7 +578,7 @@ ShallowWrapper {
                       </td>,
                     ],
                     <td>
-                      2 hours ago
+                      a few seconds ago
                     </td>,
                   ],
                 },
@@ -699,10 +699,10 @@ ShallowWrapper {
                     "key": undefined,
                     "nodeType": "host",
                     "props": Object {
-                      "children": "2 hours ago",
+                      "children": "a few seconds ago",
                     },
                     "ref": null,
-                    "rendered": "2 hours ago",
+                    "rendered": "a few seconds ago",
                     "type": "td",
                   },
                 ],
@@ -806,7 +806,7 @@ ShallowWrapper {
                   N/A
                 </td>
                 <td>
-                  2 hours ago
+                  a few seconds ago
                 </td>
               </tr>
             </tbody>
@@ -908,7 +908,7 @@ ShallowWrapper {
                     N/A
                   </td>
                   <td>
-                    2 hours ago
+                    a few seconds ago
                   </td>
                 </tr>
               </tbody>,
@@ -1146,7 +1146,7 @@ ShallowWrapper {
                       N/A
                     </td>
                     <td>
-                      2 hours ago
+                      a few seconds ago
                     </td>
                   </tr>,
                 ],
@@ -1204,7 +1204,7 @@ ShallowWrapper {
                         </td>,
                       ],
                       <td>
-                        2 hours ago
+                        a few seconds ago
                       </td>,
                     ],
                   },
@@ -1325,10 +1325,10 @@ ShallowWrapper {
                       "key": undefined,
                       "nodeType": "host",
                       "props": Object {
-                        "children": "2 hours ago",
+                        "children": "a few seconds ago",
                       },
                       "ref": null,
-                      "rendered": "2 hours ago",
+                      "rendered": "a few seconds ago",
                       "type": "td",
                     },
                   ],

--- a/frontend/test/components/measuretable.spec.jsx
+++ b/frontend/test/components/measuretable.spec.jsx
@@ -2,6 +2,10 @@ import { shallow, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import MeasureTable from '../../ui/measuretable';
 
+const referenceDate = new Date('2018-11-20T15:00:00Z');
+
+Date.now = jest.fn(() => referenceDate.getTime());
+
 configure({ adapter: new Adapter() });
 describe('MeasureTable', () => {
   it('should render the measures table correctly', () => {


### PR DESCRIPTION
Fixes #338. 

`lastUpdated` has been updated by a static function `Date.now = jest.fn(() => 1482363367071);`.
@wlach please review.