### PR TITLE
Remove pyyaml dependency

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -220,9 +220,6 @@ vine==1.1.4 \
     --hash=sha256:6849544be74ec3638e84d90bc1cf2e1e9224cc10d96cd4383ec3f69e9bce077b \
     --hash=sha256:52116d59bc45392af9fdd3b75ed98ae48a93e822cee21e5fda249105c59a7a72
 
-# Used by Django's YAML serializer.
-PyYAML==3.12 --hash=sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab
-
 # required by aiohttp
 async_timeout==2.0.1 \
     --hash=sha256:00cff4d2dce744607335cba84e9929c3165632da2d27970dbc55802a0c7873d0 \


### PR DESCRIPTION
Don't actually need it for anything. It is used by django's yaml 
serializer, but we're not serializing anything to/from yaml.