### PR TITLE
Remove test-ci image from docker-compose configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
           name: Test Code
           command: |
             cp .env-dist .env
+            make build
             docker-compose run -e DEVELOPMENT web pytest tests/ missioncontrol/
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           name: Test Code
           command: |
             cp .env-dist .env
-            docker-compose run -e DEVELOPMENT test-ci
+            docker-compose run -e DEVELOPMENT web pytest tests/ missioncontrol/
 
   deploy:
     docker:

--- a/bin/run
+++ b/bin/run
@@ -57,13 +57,6 @@ case $1 in
       events -l info -c django_celery_monitor.camera.Camera --frequency=2.0 \
       --pidfile ${MONITOR_PIDFILE}
     ;;
-  test)
-    pytest tests/ missioncontrol/
-    if [[ ! -z ${CI+check} ]]; then
-      # submit coverage
-      bash <(curl -s https://codecov.io/bash) -s /tmp
-    fi
-    ;;
   *)
     exec "$@"
     ;;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       command: "true"
 
   web:
+      image: app:build
       extends:
         service: app
       ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       command: "true"
 
   web:
-      image: app:build
       extends:
         service: app
       ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,19 +15,6 @@ services:
         - .env
       command: "true"
 
-  test-ci:
-      image: app:build
-      ports:
-        - "8000:8000"
-      depends_on:
-        - db
-        - presto
-        - redis
-      env_file:
-        - .env
-      command:
-        "test"
-
   web:
       extends:
         service: app


### PR DESCRIPTION
The test-ci image makes it impossible to bring up the docker-compose
environment locally, since it conflicts with the "web" image. Instead,
let's just run the tests inside the web image itself. All of this
is only relevant inside the circle environment.

(note that this change removes the code to call codecov, but that
was not active anyway)