### PR TITLE
Wrap create operations that may fail in transaction.atomic

### DIFF
--- a/missioncontrol/etl/builds.py
+++ b/missioncontrol/etl/builds.py
@@ -3,6 +3,7 @@ import asyncio
 import datetime
 import json
 
+from django.db import transaction
 from django.db.utils import IntegrityError
 from django.utils import timezone
 
@@ -99,9 +100,10 @@ async def _fetch_version_data(session, buildhub_platform_name, application,
     for r in aggs:
         for version_record in r['version']['buckets']:
             try:
-                Build.objects.create(application=application, platform=platform,
-                                     channel=channel, build_id=r['key'],
-                                     version=version_record['key'])
+                with transaction.atomic():
+                    Build.objects.create(application=application, platform=platform,
+                                         channel=channel, build_id=r['key'],
+                                         version=version_record['key'])
             except IntegrityError:
                 # already exists
                 pass

--- a/missioncontrol/etl/measure.py
+++ b/missioncontrol/etl/measure.py
@@ -5,6 +5,7 @@ from pkg_resources import parse_version
 
 import newrelic.agent
 from django.core.cache import cache
+from django.db import transaction
 from django.db.models import Max
 from django.db.utils import IntegrityError
 
@@ -158,7 +159,8 @@ def update_measures(application_name, platform_name, channel_name,
     else:
         for datum_obj in datum_objs:
             try:
-                datum_obj.save()
+                with transaction.atomic():
+                    datum_obj.save()
             except IntegrityError:
                 continue
 


### PR DESCRIPTION
This is expected in more recent versions of django, see: https://docs.djangoproject.com/en/1.8/topics/db/transactions/#controlling-transactions-explicitly