### PR TITLE
Sort platforms by id

### DIFF
--- a/missioncontrol/api/views.py
+++ b/missioncontrol/api/views.py
@@ -66,7 +66,7 @@ def channel_platform_summary(request):
     if application_filter:
         applications = applications.filter(name__in=application_filter)
 
-    platforms = Platform.objects.all()
+    platforms = Platform.objects.order_by('id').all()
     if platform_filter:
         platforms = platforms.filter(name__in=platform_filter)
 


### PR DESCRIPTION
Platform order in postgres was changed because of the `UPDATE`s required.  This makes the order deterministic