### PR TITLE
[Bug 1751861] Fix display_version comparison to account for 100+ versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ WORKDIR /app
 
 # First copy requirements so we can take advantage of docker caching.
 COPY requirements/*.txt /app/
+
+# temporary workaround for the following error: ImportError: cannot import name 'Feature' from 'setuptools'
+RUN pip install setuptools==45
+
 RUN pip install --require-hashes --no-cache-dir -r all.txt
 
 COPY . /app

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -5,6 +5,10 @@ services:
     image: postgres:9.5-alpine
     logging:
       driver: "none"
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
 
   redis:
     image: redis:3.2-alpine

--- a/missioncontrol/etl/measure.py
+++ b/missioncontrol/etl/measure.py
@@ -113,8 +113,8 @@ def update_measures(application_name, platform_name, channel_name,
     WHERE
         submission_date = \'{submission_date.strftime('%Y-%m-%d')}\'
         AND application = \'{params['application_name']}\'
-        AND display_version > \'{params['min_version']}\'
-        AND display_version < \'{params['max_version']}\'
+        AND mozfun.norm.truncate_version(display_version, \'major\') > {params['min_version']}
+        AND mozfun.norm.truncate_version(display_version, \'major\') < {params['max_version']}
         AND build_id > \'{params['min_build_id']}\'
         AND build_id < \'{params['max_build_id']}\'
         AND os_name = \'{params['os_name']}\'


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1751861

With FF version 100 being released the SQL query is filtering out data incorrectly. The SQL query is filtering for example on `display_version > '97' AND display_version < '100'`. However the `'97'` string is actually "larger" than `'100'`. This explains the missing data and why values were lower for a while starting around March.

cc @whd 